### PR TITLE
feat: agregar endpoint /public/health y configuración inicial

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+		<!-- Swagger / OpenAPI UI -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/ar/edu/utn/recti/web/PublicHealthController.java
+++ b/src/main/java/ar/edu/utn/recti/web/PublicHealthController.java
@@ -1,0 +1,15 @@
+package ar.edu.utn.recti.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.Map;
+
+@RestController
+
+public class PublicHealthController {
+
+    @GetMapping("/public/health")
+    public Map<String, String> health() {
+        return Map.of("status", "ok");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=recti

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,50 @@
+#spring.application.name=recti
+spring:
+  application:
+    name: recti
+  profiles:
+    active: dev  # por defecto levanta dev
+
+# ---- DEV (usa PostgreSQL en Docker de Jaz)
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:postgresql://localhost:5432/recti
+    username: recti
+    password: recti
+  jpa:
+    hibernate:
+      ddl-auto: validate   # validamos contra el schema de Flyway
+    show-sql: true
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+server:
+  port: 8080
+
+# ---- TEST (usa H2 en memoria + modo PostgreSQL)
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:recti_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+# logging opcional más limpio en test
+logging:
+  level:
+    root: INFO


### PR DESCRIPTION
Se agregó el endpoint /public/health para verificar que la aplicación esté corriendo.

Se configuraron los perfiles dev (Postgres en Docker) y test (H2 en memoria).

Se integró Flyway para manejo de migraciones.

Se validó que la aplicación arranque correctamente en localhost:8080.

Cómo probarlo

Ejecutar la aplicación (RectiApplication).

Ir a: http://localhost:8080/public/health
.

Debería devolver un mensaje de confirmación (ok, status up, o similar).